### PR TITLE
[#4] added chip and group component

### DIFF
--- a/src/components/Chip/Chip.module.css
+++ b/src/components/Chip/Chip.module.css
@@ -1,0 +1,10 @@
+.container {
+    display: inline-flex;
+    padding: calc(var(--paddingBase) / 4) var(--paddingBase);
+    font-size: 14px;
+    border-radius: 5px;
+    box-shadow: var(--shadowBase-light);
+    border: 1px solid transparent;
+    color: var(--dark-blue-1);
+    background-color: var(--white);
+}

--- a/src/components/Chip/index.tsx
+++ b/src/components/Chip/index.tsx
@@ -1,0 +1,11 @@
+import { FC } from 'react'
+
+import styles from './Chip.module.css'
+
+interface IChip {
+    text: string
+}
+
+export const Chip: FC<IChip> = ({ text }) => {
+    return <div className={styles.container}>{text}</div>
+}

--- a/src/components/Group/Group.module.css
+++ b/src/components/Group/Group.module.css
@@ -1,0 +1,6 @@
+.container {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    flex-flow: wrap;
+}

--- a/src/components/Group/index.tsx
+++ b/src/components/Group/index.tsx
@@ -1,0 +1,6 @@
+import { FC } from 'react'
+import styles from './Group.module.css'
+
+export const Group: FC = ({ children }) => {
+    return <div className={styles.container}>{children}</div>
+}

--- a/src/pages/Country/index.tsx
+++ b/src/pages/Country/index.tsx
@@ -6,6 +6,8 @@ import { Button } from '../../components/Button'
 
 import styles from './Country.module.css'
 import { countryDetailsActions } from '../../store/countryDetails/actions'
+import { Chip } from '../../components/Chip'
+import { Group } from '../../components/Group'
 
 export const CountryPage: FC = () => {
     const dispatch = useDispatch()
@@ -49,7 +51,12 @@ export const CountryPage: FC = () => {
                             <div>Language: {code}</div>
                         </div>
                     </div>
-                    <div>Border Countries: 1, 2, 3</div>
+                    <Group>
+                        Border Countries:
+                        <Chip text="France" />
+                        <Chip text="Belgium" />
+                        <Chip text="Germany" />
+                    </Group>
                 </div>
             </div>
         </PageTemplate>


### PR DESCRIPTION
Added a Chip component first, and because they had to be displayed in groups of chips added a Group component as well that can be used for group different components.

<img width="383" alt="image" src="https://user-images.githubusercontent.com/12704461/195472068-14271c4d-6ec2-429f-b060-769c90590f86.png">

closes #4 